### PR TITLE
Fixes popups overlapping issues.

### DIFF
--- a/source/scss/sections/_information.scss
+++ b/source/scss/sections/_information.scss
@@ -1,7 +1,7 @@
 #information-container {
   display: none;
   position: absolute;
-  z-index: 5;
+  z-index: 10;
   top: 0;
   left: 0;
   right: 0;

--- a/source/scss/sections/_options.scss
+++ b/source/scss/sections/_options.scss
@@ -1,7 +1,7 @@
 #options-container {
   display: none;
   position: absolute;
-  z-index: 5;
+  z-index: 10;
   top: 0;
   left: 0;
   right: 0;


### PR DESCRIPTION
Hey!

Thanks for such a great tool. I'm loving it!

There's a little issue I've spotted during working with the site. The problem is that when the editor box is expanded and its scrollbars are visible, and you would open some popup window (info or settings) then the editor scrollbars would _overlap_ the popup. [Here](http://i67.tinypic.com/xljndf.png)'s what I mean. So I've increased the value of `z-index` rule for the popups styles and that did the trick.

Thanks and have a nice day!
